### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple Node.js MCP (Model Context Protocol) server for sending emails using TurboSMTP, designed for easy integration and testing. This server exposes an MCP-compatible API endpoint to allow other services to send emails via TurboSMTP.
 
+<a href="https://glama.ai/mcp/servers/@debba/turbosmtp-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@debba/turbosmtp-mcp-server/badge" alt="turbosmtp MCP server" />
+</a>
+
 ## Features
 
 - Send emails via TurboSMTP with a simple MCP API


### PR DESCRIPTION
This PR adds a badge for the [turbosmtp](https://glama.ai/mcp/servers/@debba/turbosmtp-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@debba/turbosmtp-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@debba/turbosmtp-mcp-server/badge" alt="turbosmtp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.